### PR TITLE
feat: 新增删除数据库接口，用于特定场景（如数据恢复时，临时导入数据库进行合并操作后删除）。

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,11 @@ class UserDao2 {
  this.message = `${JSON.stringify(result)}`
 ```
 
+## 8 删除数据库
+deleteBackupDb(context: Context) {
+  sql.getDbHelper("backup").deleteDb(context, "backup.db")
+}
+
 ## 开源协议
 
 本项目基于 [Apache License 2.0](https://github.com/liushengyi/smartdb/blob/master/library/LICENSE) ，请自由地享受和参与开源。

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ class AppDB {
     //配置RdbStore属性
     //sql.dbHelper.initDbWithConfig
   }
+
+  deleteBackupDb(context: Context) {
+    sql.getDbHelper("test").deleteDb(context, "test.db")
+  }
 }
 
 class AppDbOpenHelper extends sql.DbOpenHelper {
@@ -210,11 +214,6 @@ class UserDao2 {
  let result = await userDao.searchUser("name like 'id%'")
  this.message = `${JSON.stringify(result)}`
 ```
-
-## 8 删除数据库
-deleteBackupDb(context: Context) {
-  sql.getDbHelper("backup").deleteDb(context, "backup.db")
-}
 
 ## 开源协议
 

--- a/library/src/main/ets/DbHelper.ts
+++ b/library/src/main/ets/DbHelper.ts
@@ -21,6 +21,13 @@ export class DbHelper {
     }, dbVersion, dbOpenHelper)
   }
 
+  async deleteDb(context: any, dbName: string) {
+    await relationalStore.deleteRdbStore(context, {
+      name: dbName,
+      securityLevel: relationalStore.SecurityLevel.S1
+    })
+  }
+
   async initDbWithConfig(context: any, storeConfig: relationalStore.StoreConfig, dbVersion: number, dbOpenHelper: DbOpenHelper) {
     if (dbVersion <= 0) {
       throw new Error("dbVersion must > 0");


### PR DESCRIPTION
在数据恢复或数据整合过程中，可能需要临时引入一个数据库进行合并操作，并在操作完成后删除该数据库，不删除仅删除db文件会导致第二次读取数据仍然为上次数据库内数据。
当然可以手动去调用relationalStore.deleteRdbStore，但是加一个接口会更好地帮助使用它的人。
例子：
```  
deleteBackupDb(context: Context) {
    sql.getDbHelper("backup").deleteDb(context, "backup.db")
}
```